### PR TITLE
Re #6 - refactor test data + add test + fix to converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,3 @@ path = "src/ssm_file_converter/version.py"
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
-
-
-

--- a/src/ssm_file_converter/services/ssm_json_converter.py
+++ b/src/ssm_file_converter/services/ssm_json_converter.py
@@ -71,7 +71,7 @@ def scidata_to_ssm_json(scidata: SciData) -> dict:
             output_facet_list = list()
 
             # Regular expression to pull out ID in JSON-LD for grouping
-            id_regex = re.compile('(.+?)/\d+')
+            id_regex = re.compile(r'(.+?)/\d+')
 
             for facet in facets_list:
                 # Pull out ID, cleanup facet, add new format facet in output
@@ -93,7 +93,8 @@ def scidata_to_ssm_json(scidata: SciData) -> dict:
                         elif isinstance(value, list):
                             new_facet = {id: value + [facet]}
                         else:
-                            raise Exception(f"type of facet unhandled: {output_facet}")
+                            msg = f"type of facet unhandled: {output_facet}"
+                            raise Exception(msg)
 
                 output_facet_list.append(new_facet)
 

--- a/tests/apis/version1/test_convert.py
+++ b/tests/apis/version1/test_convert.py
@@ -125,6 +125,9 @@ def test_convert_jcamp_to_jsonld(
         output.pop(key)
         target.pop(key)
 
+    # Removes system section from target since info not in JCAMP file
+    target["@graph"]["scidata"].pop("system")
+
     # Property isn't included so remove
     target["@graph"]["scidata"].pop("property")
 
@@ -156,6 +159,9 @@ def test_convert_jcamp_to_abbreviated_json(
     assert output_source == target_source
     target.pop("sources")
     output.pop("sources")
+
+    # Removes system section from target since info not in JCAMP file
+    target["scidata"].pop("system")
 
     # Property isn't included so remove
     target["scidata"].pop("property")

--- a/tests/data/scidata-jsonld/raman_soddyite.jsonld
+++ b/tests/data/scidata-jsonld/raman_soddyite.jsonld
@@ -65,6 +65,58 @@
           }
         ]
       },
+      "system": {
+        "@id": "system/",
+        "@type": "sdo:system",
+        "facets": [
+          {
+            "@id": "material/1/",
+            "@type": "sdo:material",
+            "name": "Soddyite",
+            "materialType": "(UO_2_)_2_SiO_4_&#183;2H_2_O"
+          },
+          {
+            "@id": "compound/1/",
+            "@type": "sdo:compound",
+            "formula": "(UO2)2SiO4 · 2H2O",
+            "name": "soddyite"
+          },
+          {
+            "@id": "functionalgroup/1",
+            "@type": "sdo:molsystem",
+            "atoms": "U",
+            "multiplicity": 2
+          },
+          {
+            "@id": "functionalgroup/2",
+            "@type": "sdo:molsystem",
+            "atoms": "H2O",
+            "multiplicity": 2
+          },
+          {
+            "@id": "functionalgroup/3",
+            "@type": "sdo:molsystem",
+            "atoms": "SiO",
+            "multiplicity": 1
+          },
+          {
+            "@id": "structuretype/1/",
+            "@type": "sdo:value",
+            "structure type": "framework"
+          },
+          {
+            "@id": "crystalsystem/1/",
+            "@type": "sdo:value",
+            "crystal system": "orthorhombic"
+          },
+          {
+            "@id": "coordinationchemistry/2/",
+            "@type": "sdo:value",
+            "uranium coordination chemistry": "pentagonal",
+            "multiplicity": 1
+          }
+        ]
+      },
       "dataset": {
         "@id": "dataset/",
         "@type": "sdo:dataset",

--- a/tests/data/ssm-json/nmr_limonene.json
+++ b/tests/data/ssm-json/nmr_limonene.json
@@ -102,32 +102,48 @@
             ]
         },
         "system": {
-            "name": "(+)-(r)-limonene and Chloroform-d",
-            "formula": "CHCl3",
-            "molweight": "120.384",
-            "inchi": "InChI=1S/CHCl3/c2-1(3)4/h1H/i1D",
-            "inchikey": "HEDRZPFGACZZDS-MICDWDOJSA-N",
-            "iupacname": "trichloro(deuterio)methane",
-            "chebi": "obo:CHEBI_35255",
-            "description": "A mixture of two organic compounds",
-            "mixtype": [
-                "sub:homogeneousSolution",
-                "sub:binaryMixture"
-            ],
-            "phase": "sub:liquid",
-            "constituents": [
-                {
-                    "@id": "constituent/1/",
-                    "@type": "sdo:constituent",
-                    "scope": "substance/1/",
-                    "role": "chm:solute"
-                },
-                {
-                    "@id": "constituent/2/",
-                    "@type": "sdo:constituent",
-                    "scope": "substance/2/",
-                    "role": "chm:solvent"
-                }
+            "mixture": {
+                "name": "(+)-(r)-limonene and Chloroform-d",
+                "description": "A mixture of two organic compounds",
+                "mixtype": [
+                    "sub:homogeneousSolution",
+                    "sub:binaryMixture"
+                ],
+                "phase": "sub:liquid",
+                "constituents": [
+                    {
+                        "@id": "constituent/1/",
+                        "@type": "sdo:constituent",
+                        "scope": "substance/1/",
+                        "role": "chm:solute"
+                    },
+                    {
+                        "@id": "constituent/2/",
+                        "@type": "sdo:constituent",
+                        "scope": "substance/2/",
+                        "role": "chm:solvent"
+                    }
+                ]
+            },
+            "substance": [
+              {
+                "name": "(+)-(r)-limonene",
+                "formula": "C10H16",
+                "molweight": "136.234",
+                "inchi": "InChI=1S/C10H16/c1-8(2)10-6-4-9(3)5-7-10/h4,10H,1,5-7H2,2-3H3/t10-/m0/s1",
+                "inchikey": "XMGQYMWWDOXHJM-JTQLQIEISA-N",
+                "iupacname": "(4R)-1-methyl-4-prop-1-en-2-ylcyclohexene",
+                "chebi": "obo:CHEBI_15384"
+              },
+              {
+                "name": "Chloroform-d",
+                "formula": "CHCl3",
+                "molweight": "120.384",
+                "inchi": "InChI=1S/CHCl3/c2-1(3)4/h1H/i1D",
+                "inchikey": "HEDRZPFGACZZDS-MICDWDOJSA-N",
+                "iupacname": "trichloro(deuterio)methane",
+                "chebi": "obo:CHEBI_35255"
+              }
             ]
         },
         "dataseries": [

--- a/tests/data/ssm-json/raman_soddyite.json
+++ b/tests/data/ssm-json/raman_soddyite.json
@@ -21,6 +21,40 @@
         "techniqueType": "cao:spectroscopy",
         "instrument": "Unknown"
       },
+      "system": {
+        "material": {
+          "name": "Soddyite",
+          "materialType": "(UO_2_)_2_SiO_4_&#183;2H_2_O"
+        },
+        "compound": {
+          "name": "soddyite",
+          "formula": "(UO2)2SiO4 · 2H2O"
+        },
+        "functionalgroup": [
+          {
+            "atoms": "U",
+            "multiplicity": 2
+          },
+          {
+            "atoms": "H2O",
+            "multiplicity": 2
+          },
+          {
+            "atoms": "SiO",
+            "multiplicity": 1
+          }
+        ],
+        "structuretype": {
+          "structure type": "framework"
+        },
+        "crystalsystem": {
+          "crystal system": "orthorhombic"
+        },
+        "coordinationchemistry": {
+          "uranium coordination chemistry": "pentagonal",
+          "multiplicity": 1
+        }
+      },
       "dataseries": [
         {
           "x-axis": {

--- a/tests/data/ssm-json/raman_studtite.json
+++ b/tests/data/ssm-json/raman_studtite.json
@@ -37,8 +37,10 @@
       ]
     },
     "system": {
-      "name": "Studtite",
-      "materialType": "(UO2O2_4H2O)"
+      "material": {
+        "name": "Studtite",
+        "materialType": "(UO2O2_4H2O)"
+      }
     },
     "dataseries": [
       {

--- a/tests/services/test_scidata_merger.py
+++ b/tests/services/test_scidata_merger.py
@@ -40,8 +40,17 @@ def create_json_file(data: dict) -> str:
 
 @pytest.fixture(name="jsonld_filename")
 def fixture_jsonld_filename(raman_soddyite_scidata_jsonld_file) -> str:
-    jsonld_filename = raman_soddyite_scidata_jsonld_file.absolute()
-    return jsonld_filename
+    with open(raman_soddyite_scidata_jsonld_file.absolute(), "r") as f:
+        data = json.load(f)
+    data.get("@graph").get("scidata").pop("system")
+    jsonld_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".jsonld",
+        delete=False
+    )
+    json.dump(data, jsonld_file)
+    jsonld_file.flush()
+    return jsonld_file.name
 
 
 def test_without_keys() -> None:


### PR DESCRIPTION
Closes #6 

Work includes:
  - Adds test to catch the new `atoms` section setup
  - Refactored how facets are structured in abbreviated json to fix naming clashes in keys that causes over-writes of the JSON-LD (_root of the issue in #6_)
  - Refactors test data used for validation with the new facets setup in abbreviated json

@SmithRWORNL this will cause a possible breaking change due to the new way "system" section will look in the SSM abbreviated json. The test data for soddyite should provide an example. Sorry but not sure how to not make this breaking change and still go forward with a flexible way to translate facets and not keep this bug in. Feel free to ping me if there is a major issue with this new method.
  - Example: https://github.com/smart-spectral-matching/ssm-service-file-converter/blob/89a51b37c4d28e9425ccd868eaf88daf1bbb1bbf/tests/data/ssm-json/raman_soddyite.json#L24-L57